### PR TITLE
Improved getting neighbor chunk voxels

### DIFF
--- a/src/greedy_mesher_optimized.rs
+++ b/src/greedy_mesher_optimized.rs
@@ -61,31 +61,22 @@ pub fn build_chunk_mesh(chunks_refs: &ChunksRefs, lod: Lod) -> Option<ChunkMesh>
     }
 
     // neighbor chunk voxels.
-    // note(leddoo): couldn't be bothered to optimize these.
-    //  might be worth it though. together, they take
-    //  almost as long as the entire "inner chunk" loop.
-    for z in [0, CHUNK_SIZE_P - 1] {
-        for y in 0..CHUNK_SIZE_P {
-            for x in 0..CHUNK_SIZE_P {
-                let pos = ivec3(x as i32, y as i32, z as i32) - IVec3::ONE;
-                add_voxel_to_axis_cols(chunks_refs.get_block(pos), x, y, z, &mut axis_cols);
-            }
-        }
-    }
-    for z in 0..CHUNK_SIZE_P {
-        for y in [0, CHUNK_SIZE_P - 1] {
-            for x in 0..CHUNK_SIZE_P {
-                let pos = ivec3(x as i32, y as i32, z as i32) - IVec3::ONE;
-                add_voxel_to_axis_cols(chunks_refs.get_block(pos), x, y, z, &mut axis_cols);
-            }
-        }
-    }
-    for z in 0..CHUNK_SIZE_P {
-        for x in [0, CHUNK_SIZE_P - 1] {
-            for y in 0..CHUNK_SIZE_P {
-                let pos = ivec3(x as i32, y as i32, z as i32) - IVec3::ONE;
-                add_voxel_to_axis_cols(chunks_refs.get_block(pos), x, y, z, &mut axis_cols);
-            }
+    for a in 1..CHUNK_SIZE_P-1 {
+        for b in 1..CHUNK_SIZE_P-1 {
+            let nx = ivec3(-1i32, a as i32, b as i32);
+            let px = ivec3(CHUNK_SIZE_P as i32, a as i32, b as i32);
+            add_voxel_to_axis_cols(chunks_refs.get_block(nx), 0, a, b, &mut axis_cols);
+            add_voxel_to_axis_cols(chunks_refs.get_block(px), CHUNK_SIZE_P - 1, a, b, &mut axis_cols);
+
+            let ny = ivec3(a as i32, -1i32, b as i32);
+            let py = ivec3(a as i32, CHUNK_SIZE_P as i32, b as i32);
+            add_voxel_to_axis_cols(chunks_refs.get_block(ny), a, 0usize, b, &mut axis_cols);
+            add_voxel_to_axis_cols(chunks_refs.get_block(py), a, CHUNK_SIZE_P - 1, b, &mut axis_cols);
+
+            let nz = ivec3(a as i32, b as i32, -1i32);
+            let pz = ivec3(a as i32, b as i32, CHUNK_SIZE_P as i32);
+            add_voxel_to_axis_cols(chunks_refs.get_block(nz), a, b, 0, &mut axis_cols);
+            add_voxel_to_axis_cols(chunks_refs.get_block(pz), a, b, CHUNK_SIZE_P - 1, &mut axis_cols);
         }
     }
 

--- a/src/greedy_mesher_optimized.rs
+++ b/src/greedy_mesher_optimized.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::VecDeque,
-    time::{Duration, Instant},
 };
 
 use bevy::{math::ivec3, prelude::*, utils::HashMap};
@@ -60,23 +59,33 @@ pub fn build_chunk_mesh(chunks_refs: &ChunksRefs, lod: Lod) -> Option<ChunkMesh>
         }
     }
 
-    // neighbor chunk voxels.
-    for a in 1..CHUNK_SIZE_P-1 {
-        for b in 1..CHUNK_SIZE_P-1 {
-            let nx = ivec3(-1i32, a as i32, b as i32);
-            let px = ivec3(CHUNK_SIZE_P as i32, a as i32, b as i32);
-            add_voxel_to_axis_cols(chunks_refs.get_block(nx), 0, a, b, &mut axis_cols);
-            add_voxel_to_axis_cols(chunks_refs.get_block(px), CHUNK_SIZE_P - 1, a, b, &mut axis_cols);
+    // Process x-axis boundaries
+    for y in 0..CHUNK_SIZE_P {
+        for z in 0..CHUNK_SIZE_P {
+            let nx = ivec3(-1, y as i32, z as i32);
+            let px = ivec3(CHUNK_SIZE_P as i32, y as i32, z as i32);
+            add_voxel_to_axis_cols(chunks_refs.get_block(nx), 0, y, z, &mut axis_cols);
+            add_voxel_to_axis_cols(chunks_refs.get_block(px), CHUNK_SIZE_P - 1, y, z, &mut axis_cols);
+        }
+    }
 
-            let ny = ivec3(a as i32, -1i32, b as i32);
-            let py = ivec3(a as i32, CHUNK_SIZE_P as i32, b as i32);
-            add_voxel_to_axis_cols(chunks_refs.get_block(ny), a, 0usize, b, &mut axis_cols);
-            add_voxel_to_axis_cols(chunks_refs.get_block(py), a, CHUNK_SIZE_P - 1, b, &mut axis_cols);
+    // Process y-axis boundaries
+    for x in 0..CHUNK_SIZE_P {
+        for z in 0..CHUNK_SIZE_P {
+            let ny = ivec3(x as i32, -1, z as i32);
+            let py = ivec3(x as i32, CHUNK_SIZE_P as i32, z as i32);
+            add_voxel_to_axis_cols(chunks_refs.get_block(ny), x, 0, z, &mut axis_cols);
+            add_voxel_to_axis_cols(chunks_refs.get_block(py), x, CHUNK_SIZE_P - 1, z, &mut axis_cols);
+        }
+    }
 
-            let nz = ivec3(a as i32, b as i32, -1i32);
-            let pz = ivec3(a as i32, b as i32, CHUNK_SIZE_P as i32);
-            add_voxel_to_axis_cols(chunks_refs.get_block(nz), a, b, 0, &mut axis_cols);
-            add_voxel_to_axis_cols(chunks_refs.get_block(pz), a, b, CHUNK_SIZE_P - 1, &mut axis_cols);
+    // Process z-axis boundaries
+    for x in 0..CHUNK_SIZE_P {
+        for y in 0..CHUNK_SIZE_P {
+            let nz = ivec3(x as i32, y as i32, -1);
+            let pz = ivec3(x as i32, y as i32, CHUNK_SIZE_P as i32);
+            add_voxel_to_axis_cols(chunks_refs.get_block(nz), x, y, 0, &mut axis_cols);
+            add_voxel_to_axis_cols(chunks_refs.get_block(pz), x, y, CHUNK_SIZE_P - 1, &mut axis_cols);
         }
     }
 


### PR DESCRIPTION
Only CHUNK_SIZE x CHUNK_SIZE amount of blocks per side of a chunk have neighbours
so only CHUNK_SIZE x CHUNK_SIZE amount of blocks are added as padding per chunk side instead of CHUNK_SIZE_P x CHUNK_SIZE_P blocks.

Method to add neighbours are moved into a single nested for loop since the chunk is assumed to be a cube therefore every side of a chunk have the same amount of blocks